### PR TITLE
Relax sentencepiece dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "torch>=2.1.0",
     "diffusers~=0.28.2",
     "transformers~=4.44.2",
-    "sentencepiece~=0.1.96",
+    "sentencepiece>=0.1.96",
     "huggingface-hub~=0.25.2",
     "einops"
 ]


### PR DESCRIPTION
This commit relaxes sentencepiece dependency. On windows there are no pre-built wheels for sentencepiece satisfying the current version constraints for recent versions of python, and building from a source distribution is unreliable.