### PR TITLE
vram improvements

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -48,7 +48,7 @@ def load_unet(unet_dir):
     transformer = Transformer3DModel.from_config(transformer_config)
     unet_state_dict = safetensors.torch.load_file(unet_ckpt_path)
     transformer.load_state_dict(unet_state_dict, strict=True)
-    transformer = transformer.to(torch.bfloat16)
+    
     if torch.cuda.is_available():
         transformer = transformer.cuda()
     return transformer
@@ -317,8 +317,7 @@ def main():
     text_encoder = T5EncoderModel.from_pretrained(
         "PixArt-alpha/PixArt-XL-2-1024-MS", subfolder="text_encoder"
     ).to(torch.bfloat16)
-    if torch.cuda.is_available():
-        text_encoder = text_encoder # .to(torch.bfloat16).to("cuda")
+
     tokenizer = T5Tokenizer.from_pretrained(
         "PixArt-alpha/PixArt-XL-2-1024-MS", subfolder="tokenizer"
     )

--- a/inference.py
+++ b/inference.py
@@ -48,7 +48,7 @@ def load_unet(unet_dir):
     transformer = Transformer3DModel.from_config(transformer_config)
     unet_state_dict = safetensors.torch.load_file(unet_ckpt_path)
     transformer.load_state_dict(unet_state_dict, strict=True)
-    
+    transformer = transformer.to(torch.bfloat16)
     if torch.cuda.is_available():
         transformer = transformer.cuda()
     return transformer
@@ -249,7 +249,6 @@ def main():
     parser.add_argument(
         "--disable_load_needed_only",
         action="store_true",
-        default=False,
         help="disables load_needed_only, which loads text encoder only when needed and unloads transformer model before vae decoding",
     )
 
@@ -317,7 +316,8 @@ def main():
     text_encoder = T5EncoderModel.from_pretrained(
         "PixArt-alpha/PixArt-XL-2-1024-MS", subfolder="text_encoder"
     ).to(torch.bfloat16)
-
+    if torch.cuda.is_available():
+        text_encoder = text_encoder # .to(torch.bfloat16).to("cuda")
     tokenizer = T5Tokenizer.from_pretrained(
         "PixArt-alpha/PixArt-XL-2-1024-MS", subfolder="tokenizer"
     )
@@ -336,7 +336,7 @@ def main():
     }
 
     pipeline = LTXVideoPipeline(**submodel_dict)
-    if torch.cuda.is_available() and args.disable_load_needed_only:
+    if torch.cuda.is_available():
         pipeline = pipeline.to("cuda")
 
     # Prepare input for the pipeline

--- a/inference.py
+++ b/inference.py
@@ -316,8 +316,6 @@ def main():
     text_encoder = T5EncoderModel.from_pretrained(
         "PixArt-alpha/PixArt-XL-2-1024-MS", subfolder="text_encoder"
     ).to(torch.bfloat16)
-    if torch.cuda.is_available():
-        text_encoder = text_encoder # .to(torch.bfloat16).to("cuda")
     tokenizer = T5Tokenizer.from_pretrained(
         "PixArt-alpha/PixArt-XL-2-1024-MS", subfolder="tokenizer"
     )

--- a/ltx_video/pipelines/pipeline_ltx_video.py
+++ b/ltx_video/pipelines/pipeline_ltx_video.py
@@ -683,10 +683,10 @@ class LTXVideoPipeline(DiffusionPipeline):
 
         if latents is None:
             latents = randn_tensor(
-                shape, generator=generator, device=device, dtype=dtype
+                shape, generator=generator, device=generator.device, dtype=dtype
             )
         elif latents_mask is not None:
-            noise = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+            noise = randn_tensor(shape, generator=generator, device=generator.device, dtype=dtype)
             latents = latents * latents_mask[..., None] + noise * (
                 1 - latents_mask[..., None]
             )

--- a/ltx_video/pipelines/pipeline_ltx_video.py
+++ b/ltx_video/pipelines/pipeline_ltx_video.py
@@ -299,6 +299,8 @@ class LTXVideoPipeline(DiffusionPipeline):
         # FIXME: to be configured in config not hardecoded. Fix in separate PR with rest of config
         max_length = 128  # TPU supports only lengths multiple of 128
 
+        text_enc_device = next(self.text_encoder.parameters()).device
+
         if prompt_embeds is None:
             prompt = self._text_preprocessing(prompt, clean_caption=clean_caption)
             text_inputs = self.tokenizer(
@@ -326,10 +328,10 @@ class LTXVideoPipeline(DiffusionPipeline):
                 )
 
             prompt_attention_mask = text_inputs.attention_mask
-            prompt_attention_mask = prompt_attention_mask.to(device)
+            prompt_attention_mask = prompt_attention_mask.to(text_enc_device)
 
             prompt_embeds = self.text_encoder(
-                text_input_ids.to(device), attention_mask=prompt_attention_mask
+                text_input_ids.to(text_enc_device), attention_mask=prompt_attention_mask
             )
             prompt_embeds = prompt_embeds[0]
 
@@ -370,10 +372,10 @@ class LTXVideoPipeline(DiffusionPipeline):
                 return_tensors="pt",
             )
             negative_prompt_attention_mask = uncond_input.attention_mask
-            negative_prompt_attention_mask = negative_prompt_attention_mask.to(device)
+            negative_prompt_attention_mask = negative_prompt_attention_mask.to(text_enc_device)
 
             negative_prompt_embeds = self.text_encoder(
-                uncond_input.input_ids.to(device),
+                uncond_input.input_ids.to(text_enc_device),
                 attention_mask=negative_prompt_attention_mask,
             )
             negative_prompt_embeds = negative_prompt_embeds[0]
@@ -762,6 +764,7 @@ class LTXVideoPipeline(DiffusionPipeline):
         clean_caption: bool = True,
         media_items: Optional[torch.FloatTensor] = None,
         mixed_precision: bool = False,
+        load_needed_only: bool = False,
         **kwargs,
     ) -> Union[ImagePipelineOutput, Tuple]:
         """
@@ -870,6 +873,9 @@ class LTXVideoPipeline(DiffusionPipeline):
         do_classifier_free_guidance = guidance_scale > 1.0
 
         # 3. Encode input prompt
+        if load_needed_only:
+            self.text_encoder = self.text_encoder.cuda()
+
         (
             prompt_embeds,
             prompt_attention_mask,
@@ -887,6 +893,13 @@ class LTXVideoPipeline(DiffusionPipeline):
             negative_prompt_attention_mask=negative_prompt_attention_mask,
             clean_caption=clean_caption,
         )
+
+        if load_needed_only:
+            self.text_encoder = self.text_encoder.cpu()
+
+        if load_needed_only:
+            self.transformer = self.transformer.cuda()
+
         if do_classifier_free_guidance:
             prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
             prompt_attention_mask = torch.cat(
@@ -1064,6 +1077,10 @@ class LTXVideoPipeline(DiffusionPipeline):
 
                 if callback_on_step_end is not None:
                     callback_on_step_end(self, i, t, {})
+
+        if load_needed_only:
+            self.transformer = self.transformer.cpu()
+            torch.cuda.empty_cache()
 
         latents = self.patchifier.unpatchify(
             latents=latents,


### PR DESCRIPTION
improved vram usage a lot by removing text encoder from vram after generating embeddings and offloading unet before vae decoding to avoid vram spike at the end of generation