### PR TITLE
Add command line flag to specify device for inference

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -28,6 +28,7 @@ MAX_HEIGHT = 720
 MAX_WIDTH = 1280
 MAX_NUM_FRAMES = 257
 
+
 def load_vae(vae_dir, device):
     vae_ckpt_path = vae_dir / "vae_diffusion_pytorch_model.safetensors"
     vae_config_path = vae_dir / "config.json"
@@ -86,7 +87,6 @@ def load_image_to_tensor_with_resize_and_crop(
 def calculate_padding(
     source_height: int, source_width: int, target_height: int, target_width: int
 ) -> tuple[int, int, int, int]:
-
     # Calculate total padding needed
     pad_height = target_height - source_height
     pad_width = target_width - source_width
@@ -258,7 +258,9 @@ def main():
 
     device = args.device
     if device == "cuda" and not torch.cuda.is_available():
-        logger.warning("cuda is not available. Falling back to cpu. Use --device to specify device.")
+        logger.warning(
+            "Device 'cuda' is not available. Falling back to 'cpu'. Use --device to specify device."
+        )
         device = "cpu"
 
     output_dir = (


### PR DESCRIPTION
This PR adds a new command line flag `--device` that allows users to specify the device (e.g. `cuda`, `cpu`, or `mps`) to use for inference. The flag defaults to `cuda` but will automatically fall back to `cpu` if CUDA is not available. This change also updates the code to use the specified device for loading models and running the pipeline.

`torch.manual_seed` sets the seed for generating random numbers on all devices. I removed the redundant call to `torch.cuda.manual_seed`.

This code was generated while working on pytorch/pytorch#141471. Note that LTX-Video does not currently work when using MPS as the backend in latest PyTorch. This is a regression as it worked in PyTorch v2.4.1. Please follow pytorch/pytorch#141471 if you'd like updates on progress towards a fix.