### PR TITLE
Ignore default inference.py output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,5 @@ cython_debug/
 .idea/
 
 # From inference.py
+outputs/
 video_output_*.mp4


### PR DESCRIPTION
inference.py writes files to the `outputs` folder by default, which is not gitignored. It is unlikely that a developer want these files added to the commit. This PR proposes to add the `outputs` folder to gitignore.