### PR TITLE
Add link to Replicate demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ with realistic and diverse content.
 ## Online demo
 The model is accessible right away via following links:
 - [HF Playground](https://huggingface.co/spaces/Lightricks/LTX-Video-Playground)
+- [Replicate text-to-video and image-to-video](https://replicate.com/fofr/ltx-video)
 - [Fal.ai text-to-video](https://fal.ai/models/fal-ai/ltx-video)
 - [Fal.ai image-to-video](https://fal.ai/models/fal-ai/ltx-video/image-to-video)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with realistic and diverse content.
 ## Online demo
 The model is accessible right away via following links:
 - [HF Playground](https://huggingface.co/spaces/Lightricks/LTX-Video-Playground)
-- [Replicate text-to-video and image-to-video](https://replicate.com/fofr/ltx-video)
+- [Replicate text-to-video and image-to-video](https://replicate.com/lightricks/ltx-video)
 - [Fal.ai text-to-video](https://fal.ai/models/fal-ai/ltx-video)
 - [Fal.ai image-to-video](https://fal.ai/models/fal-ai/ltx-video/image-to-video)
 


### PR DESCRIPTION
We've added LTX to Replicate here:
https://replicate.com/fofr/ltx-video

I'd love to move this to your organization on Replicate as well, so the URL would be:

https://replicate.com/lightricks/ltx-video

Please let me know if you're ok with that.