### PR TITLE
Update Table of Contents Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ This is the official repository for LTX-Video.
   - [Diffusers Integration](#diffusers-integration)
 - [Model User Guide](#model-user-guide)
 - [Community Contribution](#community-contribution)
-- [Training](#trining)
-- [Join Us!](#join-us)
+- [Training](#training)
+- [Join Us!](#join-us-)
 - [Acknowledgement](#acknowledgement)
 
 # Introduction


### PR DESCRIPTION
Fix two links within the readme's table of contents that reference sections of the readme that were not working.

`Training` and `Join Us!` links were not linking to any sections because of a typo or incomplete reference. Fixed `#trining` -> `#training` and `#join-us` -> `#join-us-`. Testing both shows that they are working on GitHub now: https://github.com/rickbau5/LTX-Video/blob/patch-1/README.md