### PR TITLE
LTX-Video: New features for version v0.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the official repository for LTX-Video.
 
 [Website](https://www.lightricks.com/ltxv) |
 [Model](https://huggingface.co/Lightricks/LTX-Video) |
-[Demo](https://fal.ai/models/fal-ai/ltx-video) |
+[Demo](https://app.ltx.studio/ltx-video) |
 [Paper](https://arxiv.org/abs/2501.00103)
 
 </div>
@@ -14,6 +14,7 @@ This is the official repository for LTX-Video.
 ## Table of Contents
 
 - [Introduction](#introduction)
+- [What's new](#news)
 - [Quick Start Guide](#quick-start-guide)
   - [Online demo](#online-demo)
   - [Run locally](#run-locally)
@@ -34,6 +35,8 @@ It can generate 24 FPS videos at 768x512 resolution, faster than it takes to wat
 The model is trained on a large-scale dataset of diverse videos and can generate high-resolution videos
 with realistic and diverse content.
 
+The model supports text-to-image, image-to-video, keyframe-based animation, video extension (both forward and backward), video-to-video transformations, and any combination of these features.
+
 | | | | |
 |:---:|:---:|:---:|:---:|
 | ![example1](./docs/_static/ltx-video_example_00001.gif)<br><details style="max-width: 300px; margin: auto;"><summary>A woman with long brown hair and light skin smiles at another woman...</summary>A woman with long brown hair and light skin smiles at another woman with long blonde hair. The woman with brown hair wears a black jacket and has a small, barely noticeable mole on her right cheek. The camera angle is a close-up, focused on the woman with brown hair's face. The lighting is warm and natural, likely from the setting sun, casting a soft glow on the scene. The scene appears to be real-life footage.</details> | ![example2](./docs/_static/ltx-video_example_00002.gif)<br><details style="max-width: 300px; margin: auto;"><summary>A woman walks away from a white Jeep parked on a city street at night...</summary>A woman walks away from a white Jeep parked on a city street at night, then ascends a staircase and knocks on a door. The woman, wearing a dark jacket and jeans, walks away from the Jeep parked on the left side of the street, her back to the camera; she walks at a steady pace, her arms swinging slightly by her sides; the street is dimly lit, with streetlights casting pools of light on the wet pavement; a man in a dark jacket and jeans walks past the Jeep in the opposite direction; the camera follows the woman from behind as she walks up a set of stairs towards a building with a green door; she reaches the top of the stairs and turns left, continuing to walk towards the building; she reaches the door and knocks on it with her right hand; the camera remains stationary, focused on the doorway; the scene is captured in real-life footage.</details> | ![example3](./docs/_static/ltx-video_example_00003.gif)<br><details style="max-width: 300px; margin: auto;"><summary>A woman with blonde hair styled up, wearing a black dress...</summary>A woman with blonde hair styled up, wearing a black dress with sequins and pearl earrings, looks down with a sad expression on her face. The camera remains stationary, focused on the woman's face. The lighting is dim, casting soft shadows on her face. The scene appears to be from a movie or TV show.</details> | ![example4](./docs/_static/ltx-video_example_00004.gif)<br><details style="max-width: 300px; margin: auto;"><summary>The camera pans over a snow-covered mountain range...</summary>The camera pans over a snow-covered mountain range, revealing a vast expanse of snow-capped peaks and valleys.The mountains are covered in a thick layer of snow, with some areas appearing almost white while others have a slightly darker, almost grayish hue. The peaks are jagged and irregular, with some rising sharply into the sky while others are more rounded. The valleys are deep and narrow, with steep slopes that are also covered in snow. The trees in the foreground are mostly bare, with only a few leaves remaining on their branches. The sky is overcast, with thick clouds obscuring the sun. The overall impression is one of peace and tranquility, with the snow-covered mountains standing as a testament to the power and beauty of nature.</details> |
@@ -41,11 +44,47 @@ with realistic and diverse content.
 | ![example9](./docs/_static/ltx-video_example_00009.gif)<br><details style="max-width: 300px; margin: auto;"><summary>A man with graying hair, a beard, and a gray shirt...</summary>A man with graying hair, a beard, and a gray shirt looks down and to his right, then turns his head to the left. The camera angle is a close-up, focused on the man's face. The lighting is dim, with a greenish tint. The scene appears to be real-life footage. Step</details> | ![example10](./docs/_static/ltx-video_example_00010.gif)<br><details style="max-width: 300px; margin: auto;"><summary>A clear, turquoise river flows through a rocky canyon...</summary>A clear, turquoise river flows through a rocky canyon, cascading over a small waterfall and forming a pool of water at the bottom.The river is the main focus of the scene, with its clear water reflecting the surrounding trees and rocks. The canyon walls are steep and rocky, with some vegetation growing on them. The trees are mostly pine trees, with their green needles contrasting with the brown and gray rocks. The overall tone of the scene is one of peace and tranquility.</details> | ![example11](./docs/_static/ltx-video_example_00011.gif)<br><details style="max-width: 300px; margin: auto;"><summary>A man in a suit enters a room and speaks to two women...</summary>A man in a suit enters a room and speaks to two women sitting on a couch. The man, wearing a dark suit with a gold tie, enters the room from the left and walks towards the center of the frame. He has short gray hair, light skin, and a serious expression. He places his right hand on the back of a chair as he approaches the couch. Two women are seated on a light-colored couch in the background. The woman on the left wears a light blue sweater and has short blonde hair. The woman on the right wears a white sweater and has short blonde hair. The camera remains stationary, focusing on the man as he enters the room. The room is brightly lit, with warm tones reflecting off the walls and furniture. The scene appears to be from a film or television show.</details> | ![example12](./docs/_static/ltx-video_example_00012.gif)<br><details style="max-width: 300px; margin: auto;"><summary>The waves crash against the jagged rocks of the shoreline...</summary>The waves crash against the jagged rocks of the shoreline, sending spray high into the air.The rocks are a dark gray color, with sharp edges and deep crevices. The water is a clear blue-green, with white foam where the waves break against the rocks. The sky is a light gray, with a few white clouds dotting the horizon.</details> |
 | ![example13](./docs/_static/ltx-video_example_00013.gif)<br><details style="max-width: 300px; margin: auto;"><summary>The camera pans across a cityscape of tall buildings...</summary>The camera pans across a cityscape of tall buildings with a circular building in the center. The camera moves from left to right, showing the tops of the buildings and the circular building in the center. The buildings are various shades of gray and white, and the circular building has a green roof. The camera angle is high, looking down at the city. The lighting is bright, with the sun shining from the upper left, casting shadows from the buildings. The scene is computer-generated imagery.</details> | ![example14](./docs/_static/ltx-video_example_00014.gif)<br><details style="max-width: 300px; margin: auto;"><summary>A man walks towards a window, looks out, and then turns around...</summary>A man walks towards a window, looks out, and then turns around. He has short, dark hair, dark skin, and is wearing a brown coat over a red and gray scarf. He walks from left to right towards a window, his gaze fixed on something outside. The camera follows him from behind at a medium distance. The room is brightly lit, with white walls and a large window covered by a white curtain. As he approaches the window, he turns his head slightly to the left, then back to the right. He then turns his entire body to the right, facing the window. The camera remains stationary as he stands in front of the window. The scene is captured in real-life footage.</details> | ![example15](./docs/_static/ltx-video_example_00015.gif)<br><details style="max-width: 300px; margin: auto;"><summary>Two police officers in dark blue uniforms and matching hats...</summary>Two police officers in dark blue uniforms and matching hats enter a dimly lit room through a doorway on the left side of the frame. The first officer, with short brown hair and a mustache, steps inside first, followed by his partner, who has a shaved head and a goatee. Both officers have serious expressions and maintain a steady pace as they move deeper into the room. The camera remains stationary, capturing them from a slightly low angle as they enter. The room has exposed brick walls and a corrugated metal ceiling, with a barred window visible in the background. The lighting is low-key, casting shadows on the officers' faces and emphasizing the grim atmosphere. The scene appears to be from a film or television show.</details> | ![example16](./docs/_static/ltx-video_example_00016.gif)<br><details style="max-width: 300px; margin: auto;"><summary>A woman with short brown hair, wearing a maroon sleeveless top...</summary>A woman with short brown hair, wearing a maroon sleeveless top and a silver necklace, walks through a room while talking, then a woman with pink hair and a white shirt appears in the doorway and yells. The first woman walks from left to right, her expression serious; she has light skin and her eyebrows are slightly furrowed. The second woman stands in the doorway, her mouth open in a yell; she has light skin and her eyes are wide. The room is dimly lit, with a bookshelf visible in the background. The camera follows the first woman as she walks, then cuts to a close-up of the second woman's face. The scene is captured in real-life footage.</details> |
 
+# News
+
+## March, 5th, 2025: New checkpoint v0.9.5
+- New license for commercial use ([OpenRail-M](https://huggingface.co/Lightricks/LTX-Video/ltx-video-2b-v0.9.5.license.txt))
+- Release a new checkpoint v0.9.5 with improved quality
+- Support keyframes and video extension
+- Support higher resolutions
+- Improved prompt understanding
+- Improved VAE
+- New online web app in [LTX-Studio](https://app.ltx.studio/ltx-video)
+- Automatic prompt enhancement
+
+## February, 20th, 2025: More inference options
+- Improve STG (Spatiotemporal Guidance) for LTX-Video
+- Support MPS on macOS with PyTorch 2.3.0
+- Add support for 8-bit model, LTX-VideoQ8
+- Add TeaCache for LTX-Video
+- Add [ComfyUI-LTXTricks](#comfyui-integration)
+- Add Diffusion-Pipe
+
+## December 31st, 2024: Research paper
+- Release the [research paper](https://arxiv.org/abs/2501.00103)
+
+## December 20th, 2024: New checkpoint v0.9.1
+- Release a new checkpoint v0.9.1 with improved quality
+- Support for STG / PAG
+- Support loading checkpoints of LTX-Video in Diffusers format (conversion is done on-the-fly)
+- Support offloading unused parts to CPU
+- Support the new timestep-conditioned VAE decoder
+- Reference contributions from the community in the readme file
+- Relax transformers dependency
+
+## November 21th, 2024: Initial release v0.9.0
+- Initial release of LTX-Video
+- Support text-to-video and image-to-video generation
+
 # Quick Start Guide
 
-## Online demo
-The model is accessible right away via following links:
-- [HF Playground](https://huggingface.co/spaces/Lightricks/LTX-Video-Playground)
+## Online inference
+The model is accessible right away via the following links:
+- [LTX-Studio image-to-video](https://app.ltx.studio/ltx-video)
 - [Fal.ai text-to-video](https://fal.ai/models/fal-ai/ltx-video)
 - [Fal.ai image-to-video](https://fal.ai/models/fal-ai/ltx-video/image-to-video)
 - [Replicate text-to-video and image-to-video](https://replicate.com/lightricks/ltx-video)
@@ -71,8 +110,8 @@ Then, download the model from [Hugging Face](https://huggingface.co/Lightricks/L
 ```python
 from huggingface_hub import hf_hub_download
 
-model_path = 'PATH'   # The local directory to save downloaded checkpoint
-hf_hub_download(repo_id="Lightricks/LTX-Video", filename="ltx-video-2b-v0.9.1.safetensors", local_dir=model_path, local_dir_use_symlinks=False, repo_type='model')
+model_dir = 'MODEL_DIR'   # The local directory to save downloaded checkpoint
+hf_hub_download(repo_id="Lightricks/LTX-Video", filename="ltx-video-2b-v0.9.5.safetensors", local_dir=model_dir, local_dir_use_symlinks=False, repo_type='model')
 ```
 
 ### Inference
@@ -93,15 +132,20 @@ python inference.py --ckpt_path 'PATH' --prompt "PROMPT" --conditioning_media_pa
 
 #### Extending a video:
 
+📝 **Note:** Input video segments must contain a multiple of 8 frames plus 1 (e.g., 9, 17, 25, etc.), and the target frame number should be a multiple of 8.
+
+
 ```bash
 python inference.py --ckpt_path 'PATH' --prompt "PROMPT" --conditioning_media_paths VIDEO_PATH --conditioning_start_frames START_FRAME --height HEIGHT --width WIDTH --num_frames NUM_FRAMES --seed SEED
 ```
 
-
 #### For video generation with multiple conditions:
 
+You can now generate a video conditioned on a set of images and/or short video segments.
+Simply provide a list of paths to the images or video segments you want to condition on, along with their target frame numbers in the generated video. You can also specify the conditioning strength for each item (default: 1.0).
+
 ```bash
-python inference.py --ckpt_path 'PATH' --prompt "PROMPT" --conditioning_media_paths IMAGE_PATH1 VIDEO_PATH2 --conditioning_start_frames 0 SECOND_COND_START_FRAME --height HEIGHT --width WIDTH --num_frames NUM_FRAMES --seed SEED
+python inference.py --ckpt_path 'PATH' --prompt "PROMPT" --conditioning_media_paths IMAGE_OR_VIDEO_PATH_1 IMAGE_OR_VIDEO_PATH_2 --conditioning_start_frames TARGET_FRAME_1 TARGET_FRAME_2 --height HEIGHT --width WIDTH --num_frames NUM_FRAMES --seed SEED
 ```
 
 ## ComfyUI Integration
@@ -127,12 +171,19 @@ When writing prompts, focus on detailed, chronological descriptions of actions a
 * Note any changes or sudden events
 * See [examples](#introduction) for more inspiration.
 
+### Automatic Prompt Enhancement
+When using `inference.py`, shorts prompts (below `prompt_enhancement_words_threshold` words) are automatically enhanced by a language model. This is supported with text-to-video and image-to-video (first-frame conditioning).
+
+When using `LTXVideoPipeline` directly, you can enable prompt enhancement by setting `enhance_prompt=True`.
+
 ## 🎮 Parameter Guide
 
 * Resolution Preset: Higher resolutions for detailed scenes, lower for faster generation and simpler scenes. The model works on resolutions that are divisible by 32 and number of frames that are divisible by 8 + 1 (e.g. 257). In case the resolution or number of frames are not divisible by 32 or 8 + 1, the input will be padded with -1 and then cropped to the desired resolution and number of frames. The model works best on resolutions under 720 x 1280 and number of frames below 257
 * Seed: Save seed values to recreate specific styles or compositions you like
 * Guidance Scale: 3-3.5 are the recommended values
 * Inference Steps: More steps (40+) for quality, fewer steps (20-30) for speed
+
+📝 For advanced parameters usage, please see `python inference.py --help`
 
 ## Community Contribution
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,20 @@ python inference.py --ckpt_path 'PATH' --prompt "PROMPT" --height HEIGHT --width
 #### For image-to-video generation:
 
 ```bash
-python inference.py --ckpt_path 'PATH' --prompt "PROMPT" --input_image_path IMAGE_PATH --height HEIGHT --width WIDTH --num_frames NUM_FRAMES --seed SEED
+python inference.py --ckpt_path 'PATH' --prompt "PROMPT" --conditioning_media_paths IMAGE_PATH --conditioning_start_frames 0 --height HEIGHT --width WIDTH --num_frames NUM_FRAMES --seed SEED
+```
+
+#### Extending a video:
+
+```bash
+python inference.py --ckpt_path 'PATH' --prompt "PROMPT" --conditioning_media_paths VIDEO_PATH --conditioning_start_frames START_FRAME --height HEIGHT --width WIDTH --num_frames NUM_FRAMES --seed SEED
+```
+
+
+#### For video generation with multiple conditions:
+
+```bash
+python inference.py --ckpt_path 'PATH' --prompt "PROMPT" --conditioning_media_paths IMAGE_PATH1 VIDEO_PATH2 --conditioning_start_frames 0 SECOND_COND_START_FRAME --height HEIGHT --width WIDTH --num_frames NUM_FRAMES --seed SEED
 ```
 
 ## ComfyUI Integration

--- a/ltx_video/models/autoencoders/causal_conv3d.py
+++ b/ltx_video/models/autoencoders/causal_conv3d.py
@@ -13,6 +13,7 @@ class CausalConv3d(nn.Module):
         stride: Union[int, Tuple[int]] = 1,
         dilation: int = 1,
         groups: int = 1,
+        spatial_padding_mode: str = "zeros",
         **kwargs,
     ):
         super().__init__()
@@ -36,7 +37,7 @@ class CausalConv3d(nn.Module):
             stride=stride,
             dilation=dilation,
             padding=padding,
-            padding_mode="zeros",
+            padding_mode=spatial_padding_mode,
             groups=groups,
         )
 

--- a/ltx_video/models/autoencoders/causal_video_autoencoder.py
+++ b/ltx_video/models/autoencoders/causal_video_autoencoder.py
@@ -133,9 +133,12 @@ class CausalVideoAutoencoder(AutoencoderKLWrapper):
             "latent_log_var", "per_channel" if double_z else "none"
         )
         use_quant_conv = config.get("use_quant_conv", True)
+        normalize_latent_channels = config.get("normalize_latent_channels", False)
 
-        if use_quant_conv and latent_log_var == "uniform":
-            raise ValueError("uniform latent_log_var requires use_quant_conv=False")
+        if use_quant_conv and latent_log_var in ["uniform", "constant"]:
+            raise ValueError(
+                f"latent_log_var={latent_log_var} requires use_quant_conv=False"
+            )
 
         encoder = Encoder(
             dims=config["dims"],
@@ -145,6 +148,8 @@ class CausalVideoAutoencoder(AutoencoderKLWrapper):
             patch_size=config.get("patch_size", 1),
             latent_log_var=latent_log_var,
             norm_layer=config.get("norm_layer", "group_norm"),
+            base_channels=config.get("encoder_base_channels", 128),
+            spatial_padding_mode=config.get("spatial_padding_mode", "zeros"),
         )
 
         decoder = Decoder(
@@ -156,6 +161,8 @@ class CausalVideoAutoencoder(AutoencoderKLWrapper):
             norm_layer=config.get("norm_layer", "group_norm"),
             causal=config.get("causal_decoder", False),
             timestep_conditioning=config.get("timestep_conditioning", False),
+            base_channels=config.get("decoder_base_channels", 128),
+            spatial_padding_mode=config.get("spatial_padding_mode", "zeros"),
         )
 
         dims = config["dims"]
@@ -165,6 +172,7 @@ class CausalVideoAutoencoder(AutoencoderKLWrapper):
             latent_channels=config["latent_channels"],
             dims=dims,
             use_quant_conv=use_quant_conv,
+            normalize_latent_channels=normalize_latent_channels,
         )
 
     @property
@@ -185,6 +193,7 @@ class CausalVideoAutoencoder(AutoencoderKLWrapper):
             use_quant_conv=self.use_quant_conv,
             causal_decoder=self.decoder.causal,
             timestep_conditioning=self.decoder.timestep_conditioning,
+            normalize_latent_channels=self.normalize_latent_channels,
         )
 
     @property
@@ -202,7 +211,13 @@ class CausalVideoAutoencoder(AutoencoderKLWrapper):
                 [
                     block
                     for block in self.encoder.blocks_desc
-                    if block[0] in ["compress_space", "compress_all"]
+                    if block[0]
+                    in [
+                        "compress_space",
+                        "compress_all",
+                        "compress_all_res",
+                        "compress_space_res",
+                    ]
                 ]
             )
             * self.encoder.patch_size
@@ -214,7 +229,13 @@ class CausalVideoAutoencoder(AutoencoderKLWrapper):
             [
                 block
                 for block in self.encoder.blocks_desc
-                if block[0] in ["compress_time", "compress_all"]
+                if block[0]
+                in [
+                    "compress_time",
+                    "compress_all",
+                    "compress_all_res",
+                    "compress_space_res",
+                ]
             ]
         )
 
@@ -236,7 +257,7 @@ class CausalVideoAutoencoder(AutoencoderKLWrapper):
             if not key.startswith(PER_CHANNEL_STATISTICS_PREFIX)
         }
 
-        model_keys = set(name for name, _ in self.named_parameters())
+        model_keys = set(name for name, _ in self.named_modules())
 
         key_mapping = {
             ".resnets.": ".res_blocks.",
@@ -248,7 +269,8 @@ class CausalVideoAutoencoder(AutoencoderKLWrapper):
             for k, v in key_mapping.items():
                 key = key.replace(k, v)
 
-            if "norm" in key and key not in model_keys:
+            key_prefix = ".".join(key.split(".")[:-1])
+            if "norm" in key and key_prefix not in model_keys:
                 logger.info(
                     f"Removing key {key} from state_dict as it is not present in the model"
                 )
@@ -311,7 +333,7 @@ class Encoder(nn.Module):
         norm_layer (`str`, *optional*, defaults to `group_norm`):
             The normalization layer to use. Can be either `group_norm` or `pixel_norm`.
         latent_log_var (`str`, *optional*, defaults to `per_channel`):
-            The number of channels for the log variance. Can be either `per_channel`, `uniform`, or `none`.
+            The number of channels for the log variance. Can be either `per_channel`, `uniform`, `constant` or `none`.
     """
 
     def __init__(
@@ -325,6 +347,7 @@ class Encoder(nn.Module):
         patch_size: Union[int, Tuple[int]] = 1,
         norm_layer: str = "group_norm",  # group_norm, pixel_norm
         latent_log_var: str = "per_channel",
+        spatial_padding_mode: str = "zeros",
     ):
         super().__init__()
         self.patch_size = patch_size
@@ -344,6 +367,7 @@ class Encoder(nn.Module):
             stride=1,
             padding=1,
             causal=True,
+            spatial_padding_mode=spatial_padding_mode,
         )
 
         self.down_blocks = nn.ModuleList([])
@@ -361,6 +385,7 @@ class Encoder(nn.Module):
                     resnet_eps=1e-6,
                     resnet_groups=norm_num_groups,
                     norm_layer=norm_layer,
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "res_x_y":
                 output_channel = block_params.get("multiplier", 2) * output_channel
@@ -371,6 +396,7 @@ class Encoder(nn.Module):
                     eps=1e-6,
                     groups=norm_num_groups,
                     norm_layer=norm_layer,
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "compress_time":
                 block = make_conv_nd(
@@ -380,6 +406,7 @@ class Encoder(nn.Module):
                     kernel_size=3,
                     stride=(2, 1, 1),
                     causal=True,
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "compress_space":
                 block = make_conv_nd(
@@ -389,6 +416,7 @@ class Encoder(nn.Module):
                     kernel_size=3,
                     stride=(1, 2, 2),
                     causal=True,
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "compress_all":
                 block = make_conv_nd(
@@ -398,6 +426,7 @@ class Encoder(nn.Module):
                     kernel_size=3,
                     stride=(2, 2, 2),
                     causal=True,
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "compress_all_x_y":
                 output_channel = block_params.get("multiplier", 2) * output_channel
@@ -408,6 +437,34 @@ class Encoder(nn.Module):
                     kernel_size=3,
                     stride=(2, 2, 2),
                     causal=True,
+                    spatial_padding_mode=spatial_padding_mode,
+                )
+            elif block_name == "compress_all_res":
+                output_channel = block_params.get("multiplier", 2) * output_channel
+                block = SpaceToDepthDownsample(
+                    dims=dims,
+                    in_channels=input_channel,
+                    out_channels=output_channel,
+                    stride=(2, 2, 2),
+                    spatial_padding_mode=spatial_padding_mode,
+                )
+            elif block_name == "compress_space_res":
+                output_channel = block_params.get("multiplier", 2) * output_channel
+                block = SpaceToDepthDownsample(
+                    dims=dims,
+                    in_channels=input_channel,
+                    out_channels=output_channel,
+                    stride=(1, 2, 2),
+                    spatial_padding_mode=spatial_padding_mode,
+                )
+            elif block_name == "compress_time_res":
+                output_channel = block_params.get("multiplier", 2) * output_channel
+                block = SpaceToDepthDownsample(
+                    dims=dims,
+                    in_channels=input_channel,
+                    out_channels=output_channel,
+                    stride=(2, 1, 1),
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             else:
                 raise ValueError(f"unknown block: {block_name}")
@@ -431,10 +488,18 @@ class Encoder(nn.Module):
             conv_out_channels *= 2
         elif latent_log_var == "uniform":
             conv_out_channels += 1
+        elif latent_log_var == "constant":
+            conv_out_channels += 1
         elif latent_log_var != "none":
             raise ValueError(f"Invalid latent_log_var: {latent_log_var}")
         self.conv_out = make_conv_nd(
-            dims, output_channel, conv_out_channels, 3, padding=1, causal=True
+            dims,
+            output_channel,
+            conv_out_channels,
+            3,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
         )
 
         self.gradient_checkpointing = False
@@ -476,6 +541,15 @@ class Encoder(nn.Module):
                 sample = torch.cat([sample, repeated_last_channel], dim=1)
             else:
                 raise ValueError(f"Invalid input shape: {sample.shape}")
+        elif self.latent_log_var == "constant":
+            sample = sample[:, :-1, ...]
+            approx_ln_0 = (
+                -30
+            )  # this is the minimal clamp value in DiagonalGaussianDistribution objects
+            sample = torch.cat(
+                [sample, torch.ones_like(sample, device=sample.device) * approx_ln_0],
+                dim=1,
+            )
 
         return sample
 
@@ -518,6 +592,7 @@ class Decoder(nn.Module):
         norm_layer: str = "group_norm",
         causal: bool = True,
         timestep_conditioning: bool = False,
+        spatial_padding_mode: str = "zeros",
     ):
         super().__init__()
         self.patch_size = patch_size
@@ -543,6 +618,7 @@ class Decoder(nn.Module):
             stride=1,
             padding=1,
             causal=True,
+            spatial_padding_mode=spatial_padding_mode,
         )
 
         self.up_blocks = nn.ModuleList([])
@@ -562,6 +638,7 @@ class Decoder(nn.Module):
                     norm_layer=norm_layer,
                     inject_noise=block_params.get("inject_noise", False),
                     timestep_conditioning=timestep_conditioning,
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "attn_res_x":
                 block = UNetMidBlock3D(
@@ -573,6 +650,7 @@ class Decoder(nn.Module):
                     inject_noise=block_params.get("inject_noise", False),
                     timestep_conditioning=timestep_conditioning,
                     attention_head_dim=block_params["attention_head_dim"],
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "res_x_y":
                 output_channel = output_channel // block_params.get("multiplier", 2)
@@ -585,14 +663,21 @@ class Decoder(nn.Module):
                     norm_layer=norm_layer,
                     inject_noise=block_params.get("inject_noise", False),
                     timestep_conditioning=False,
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "compress_time":
                 block = DepthToSpaceUpsample(
-                    dims=dims, in_channels=input_channel, stride=(2, 1, 1)
+                    dims=dims,
+                    in_channels=input_channel,
+                    stride=(2, 1, 1),
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "compress_space":
                 block = DepthToSpaceUpsample(
-                    dims=dims, in_channels=input_channel, stride=(1, 2, 2)
+                    dims=dims,
+                    in_channels=input_channel,
+                    stride=(1, 2, 2),
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             elif block_name == "compress_all":
                 output_channel = output_channel // block_params.get("multiplier", 1)
@@ -602,6 +687,7 @@ class Decoder(nn.Module):
                     stride=(2, 2, 2),
                     residual=block_params.get("residual", False),
                     out_channels_reduction_factor=block_params.get("multiplier", 1),
+                    spatial_padding_mode=spatial_padding_mode,
                 )
             else:
                 raise ValueError(f"unknown layer: {block_name}")
@@ -619,7 +705,13 @@ class Decoder(nn.Module):
 
         self.conv_act = nn.SiLU()
         self.conv_out = make_conv_nd(
-            dims, output_channel, out_channels, 3, padding=1, causal=True
+            dims,
+            output_channel,
+            out_channels,
+            3,
+            padding=1,
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
         )
 
         self.gradient_checkpointing = False
@@ -745,6 +837,7 @@ class UNetMidBlock3D(nn.Module):
         inject_noise: bool = False,
         timestep_conditioning: bool = False,
         attention_head_dim: int = -1,
+        spatial_padding_mode: str = "zeros",
     ):
         super().__init__()
         resnet_groups = (
@@ -769,6 +862,7 @@ class UNetMidBlock3D(nn.Module):
                     norm_layer=norm_layer,
                     inject_noise=inject_noise,
                     timestep_conditioning=timestep_conditioning,
+                    spatial_padding_mode=spatial_padding_mode,
                 )
                 for _ in range(num_layers)
             ]
@@ -876,9 +970,62 @@ class UNetMidBlock3D(nn.Module):
         return hidden_states
 
 
+class SpaceToDepthDownsample(nn.Module):
+    def __init__(self, dims, in_channels, out_channels, stride, spatial_padding_mode):
+        super().__init__()
+        self.stride = stride
+        self.group_size = in_channels * np.prod(stride) // out_channels
+        self.conv = make_conv_nd(
+            dims=dims,
+            in_channels=in_channels,
+            out_channels=out_channels // np.prod(stride),
+            kernel_size=3,
+            stride=1,
+            causal=True,
+            spatial_padding_mode=spatial_padding_mode,
+        )
+
+    def forward(self, x, causal: bool = True):
+        if self.stride[0] == 2:
+            x = torch.cat(
+                [x[:, :, :1, :, :], x], dim=2
+            )  # duplicate first frames for padding
+
+        # skip connection
+        x_in = rearrange(
+            x,
+            "b c (d p1) (h p2) (w p3) -> b (c p1 p2 p3) d h w",
+            p1=self.stride[0],
+            p2=self.stride[1],
+            p3=self.stride[2],
+        )
+        x_in = rearrange(x_in, "b (c g) d h w -> b c g d h w", g=self.group_size)
+        x_in = x_in.mean(dim=2)
+
+        # conv
+        x = self.conv(x, causal=causal)
+        x = rearrange(
+            x,
+            "b c (d p1) (h p2) (w p3) -> b (c p1 p2 p3) d h w",
+            p1=self.stride[0],
+            p2=self.stride[1],
+            p3=self.stride[2],
+        )
+
+        x = x + x_in
+
+        return x
+
+
 class DepthToSpaceUpsample(nn.Module):
     def __init__(
-        self, dims, in_channels, stride, residual=False, out_channels_reduction_factor=1
+        self,
+        dims,
+        in_channels,
+        stride,
+        residual=False,
+        out_channels_reduction_factor=1,
+        spatial_padding_mode="zeros",
     ):
         super().__init__()
         self.stride = stride
@@ -892,6 +1039,7 @@ class DepthToSpaceUpsample(nn.Module):
             kernel_size=3,
             stride=1,
             causal=True,
+            spatial_padding_mode=spatial_padding_mode,
         )
         self.residual = residual
         self.out_channels_reduction_factor = out_channels_reduction_factor
@@ -961,6 +1109,7 @@ class ResnetBlock3D(nn.Module):
         norm_layer: str = "group_norm",
         inject_noise: bool = False,
         timestep_conditioning: bool = False,
+        spatial_padding_mode: str = "zeros",
     ):
         super().__init__()
         self.in_channels = in_channels
@@ -987,6 +1136,7 @@ class ResnetBlock3D(nn.Module):
             stride=1,
             padding=1,
             causal=True,
+            spatial_padding_mode=spatial_padding_mode,
         )
 
         if inject_noise:
@@ -1011,6 +1161,7 @@ class ResnetBlock3D(nn.Module):
             stride=1,
             padding=1,
             causal=True,
+            spatial_padding_mode=spatial_padding_mode,
         )
 
         if inject_noise:
@@ -1156,30 +1307,28 @@ def unpatchify(x, patch_size_hw, patch_size_t=1):
     return x
 
 
-def create_video_autoencoder_config(
+def create_video_autoencoder_demo_config(
     latent_channels: int = 64,
 ):
     encoder_blocks = [
-        ("res_x", {"num_layers": 4}),
-        ("compress_all_x_y", {"multiplier": 3}),
-        ("res_x", {"num_layers": 4}),
-        ("compress_all_x_y", {"multiplier": 2}),
-        ("res_x", {"num_layers": 4}),
-        ("compress_all", {}),
-        ("res_x", {"num_layers": 3}),
-        ("res_x", {"num_layers": 4}),
+        ("res_x", {"num_layers": 2}),
+        ("compress_space_res", {"multiplier": 2}),
+        ("res_x", {"num_layers": 2}),
+        ("compress_time_res", {"multiplier": 2}),
+        ("res_x", {"num_layers": 1}),
+        ("compress_all_res", {"multiplier": 2}),
+        ("res_x", {"num_layers": 1}),
+        ("compress_all_res", {"multiplier": 2}),
+        ("res_x", {"num_layers": 1}),
     ]
     decoder_blocks = [
-        ("res_x", {"num_layers": 4}),
-        ("compress_all", {"residual": True}),
-        ("res_x_y", {"multiplier": 3}),
-        ("res_x", {"num_layers": 3}),
-        ("compress_all", {"residual": True}),
-        ("res_x_y", {"multiplier": 2}),
-        ("res_x", {"num_layers": 3}),
-        ("compress_all", {"residual": True}),
-        ("res_x", {"num_layers": 3}),
-        ("res_x", {"num_layers": 4}),
+        ("res_x", {"num_layers": 2, "inject_noise": False}),
+        ("compress_all", {"residual": True, "multiplier": 2}),
+        ("res_x", {"num_layers": 2, "inject_noise": False}),
+        ("compress_all", {"residual": True, "multiplier": 2}),
+        ("res_x", {"num_layers": 2, "inject_noise": False}),
+        ("compress_all", {"residual": True, "multiplier": 2}),
+        ("res_x", {"num_layers": 2, "inject_noise": False}),
     ]
     return {
         "_class_name": "CausalVideoAutoencoder",
@@ -1193,6 +1342,7 @@ def create_video_autoencoder_config(
         "use_quant_conv": False,
         "causal_decoder": False,
         "timestep_conditioning": True,
+        "spatial_padding_mode": "replicate",
     }
 
 
@@ -1207,7 +1357,7 @@ def test_vae_patchify_unpatchify():
 
 def demo_video_autoencoder_forward_backward():
     # Configuration for the VideoAutoencoder
-    config = create_video_autoencoder_config()
+    config = create_video_autoencoder_demo_config()
 
     # Instantiate the VideoAutoencoder with the specified configuration
     video_autoencoder = CausalVideoAutoencoder.from_config(config)
@@ -1242,11 +1392,11 @@ def demo_video_autoencoder_forward_backward():
         image_latent, target_shape=image_latent.shape, timestep=timestep
     ).sample
 
-    # first_frame_latent = latent[:, :, :1, :, :]
+    first_frame_latent = latent[:, :, :1, :, :]
 
-    # assert torch.allclose(image_latent, first_frame_latent, atol=1e-6)
+    assert torch.allclose(image_latent, first_frame_latent, atol=1e-6)
     # assert torch.allclose(reconstructed_image, reconstructed_videos[:, :, :1, :, :], atol=1e-6)
-    # assert (image_latent == first_frame_latent).all()
+    # assert torch.allclose(image_latent, first_frame_latent, atol=1e-6)
     # assert (reconstructed_image == reconstructed_videos[:, :, :1, :, :]).all()
 
     # Calculate the loss (e.g., mean squared error)

--- a/ltx_video/models/autoencoders/conv_nd_factory.py
+++ b/ltx_video/models/autoencoders/conv_nd_factory.py
@@ -17,7 +17,11 @@ def make_conv_nd(
     groups=1,
     bias=True,
     causal=False,
+    spatial_padding_mode="zeros",
+    temporal_padding_mode="zeros",
 ):
+    if not (spatial_padding_mode == temporal_padding_mode or causal):
+        raise NotImplementedError("spatial and temporal padding modes must be equal")
     if dims == 2:
         return torch.nn.Conv2d(
             in_channels=in_channels,
@@ -28,6 +32,7 @@ def make_conv_nd(
             dilation=dilation,
             groups=groups,
             bias=bias,
+            padding_mode=spatial_padding_mode,
         )
     elif dims == 3:
         if causal:
@@ -40,6 +45,7 @@ def make_conv_nd(
                 dilation=dilation,
                 groups=groups,
                 bias=bias,
+                spatial_padding_mode=spatial_padding_mode,
             )
         return torch.nn.Conv3d(
             in_channels=in_channels,
@@ -50,6 +56,7 @@ def make_conv_nd(
             dilation=dilation,
             groups=groups,
             bias=bias,
+            padding_mode=spatial_padding_mode,
         )
     elif dims == (2, 1):
         return DualConv3d(
@@ -59,6 +66,7 @@ def make_conv_nd(
             stride=stride,
             padding=padding,
             bias=bias,
+            padding_mode=spatial_padding_mode,
         )
     else:
         raise ValueError(f"unsupported dimensions: {dims}")

--- a/ltx_video/models/autoencoders/dual_conv3d.py
+++ b/ltx_video/models/autoencoders/dual_conv3d.py
@@ -18,11 +18,13 @@ class DualConv3d(nn.Module):
         dilation: Union[int, Tuple[int, int, int]] = 1,
         groups=1,
         bias=True,
+        padding_mode="zeros",
     ):
         super(DualConv3d, self).__init__()
 
         self.in_channels = in_channels
         self.out_channels = out_channels
+        self.padding_mode = padding_mode
         # Ensure kernel_size, stride, padding, and dilation are tuples of length 3
         if isinstance(kernel_size, int):
             kernel_size = (kernel_size, kernel_size, kernel_size)
@@ -108,6 +110,7 @@ class DualConv3d(nn.Module):
             self.padding1,
             self.dilation1,
             self.groups,
+            padding_mode=self.padding_mode,
         )
 
         if skip_time_conv:
@@ -122,6 +125,7 @@ class DualConv3d(nn.Module):
             self.padding2,
             self.dilation2,
             self.groups,
+            padding_mode=self.padding_mode,
         )
 
         return x
@@ -137,7 +141,16 @@ class DualConv3d(nn.Module):
         stride1 = (self.stride1[1], self.stride1[2])
         padding1 = (self.padding1[1], self.padding1[2])
         dilation1 = (self.dilation1[1], self.dilation1[2])
-        x = F.conv2d(x, weight1, self.bias1, stride1, padding1, dilation1, self.groups)
+        x = F.conv2d(
+            x,
+            weight1,
+            self.bias1,
+            stride1,
+            padding1,
+            dilation1,
+            self.groups,
+            padding_mode=self.padding_mode,
+        )
 
         _, _, h, w = x.shape
 
@@ -154,7 +167,16 @@ class DualConv3d(nn.Module):
         stride2 = self.stride2[0]
         padding2 = self.padding2[0]
         dilation2 = self.dilation2[0]
-        x = F.conv1d(x, weight2, self.bias2, stride2, padding2, dilation2, self.groups)
+        x = F.conv1d(
+            x,
+            weight2,
+            self.bias2,
+            stride2,
+            padding2,
+            dilation2,
+            self.groups,
+            padding_mode=self.padding_mode,
+        )
         x = rearrange(x, "(b h w) c d -> b c d h w", b=b, h=h, w=w)
 
         return x

--- a/ltx_video/models/transformers/symmetric_patchifier.py
+++ b/ltx_video/models/transformers/symmetric_patchifier.py
@@ -6,8 +6,6 @@ from diffusers.configuration_utils import ConfigMixin
 from einops import rearrange
 from torch import Tensor
 
-from ltx_video.utils.torch_utils import append_dims
-
 
 class Patchifier(ConfigMixin, ABC):
     def __init__(self, patch_size: int):
@@ -15,10 +13,8 @@ class Patchifier(ConfigMixin, ABC):
         self._patch_size = (1, patch_size, patch_size)
 
     @abstractmethod
-    def patchify(
-        self, latents: Tensor, frame_rates: Tensor, scale_grid: bool
-    ) -> Tuple[Tensor, Tensor]:
-        pass
+    def patchify(self, latents: Tensor) -> Tuple[Tensor, Tensor]:
+        raise NotImplementedError("Patchify method not implemented")
 
     @abstractmethod
     def unpatchify(
@@ -26,7 +22,6 @@ class Patchifier(ConfigMixin, ABC):
         latents: Tensor,
         output_height: int,
         output_width: int,
-        output_num_frames: int,
         out_channels: int,
     ) -> Tuple[Tensor, Tensor]:
         pass
@@ -35,36 +30,31 @@ class Patchifier(ConfigMixin, ABC):
     def patch_size(self):
         return self._patch_size
 
-    def get_grid(
-        self, orig_num_frames, orig_height, orig_width, batch_size, scale_grid, device
+    def get_latent_coords(
+        self, latent_num_frames, latent_height, latent_width, batch_size, device
     ):
-        f = orig_num_frames // self._patch_size[0]
-        h = orig_height // self._patch_size[1]
-        w = orig_width // self._patch_size[2]
-        grid_h = torch.arange(h, dtype=torch.float32, device=device)
-        grid_w = torch.arange(w, dtype=torch.float32, device=device)
-        grid_f = torch.arange(f, dtype=torch.float32, device=device)
-        grid = torch.meshgrid(grid_f, grid_h, grid_w)
-        grid = torch.stack(grid, dim=0)
-        grid = grid.unsqueeze(0).repeat(batch_size, 1, 1, 1, 1)
-
-        if scale_grid is not None:
-            for i in range(3):
-                if isinstance(scale_grid[i], Tensor):
-                    scale = append_dims(scale_grid[i], grid.ndim - 1)
-                else:
-                    scale = scale_grid[i]
-                grid[:, i, ...] = grid[:, i, ...] * scale * self._patch_size[i]
-
-        grid = rearrange(grid, "b c f h w -> b c (f h w)", b=batch_size)
-        return grid
+        """
+        Return a tensor of shape [batch_size, 3, num_patches] containing the
+            top-left corner latent coordinates of each latent patch.
+        The tensor is repeated for each batch element.
+        """
+        latent_sample_coords = torch.meshgrid(
+            torch.arange(0, latent_num_frames, self._patch_size[0], device=device),
+            torch.arange(0, latent_height, self._patch_size[1], device=device),
+            torch.arange(0, latent_width, self._patch_size[2], device=device),
+        )
+        latent_sample_coords = torch.stack(latent_sample_coords, dim=0)
+        latent_coords = latent_sample_coords.unsqueeze(0).repeat(batch_size, 1, 1, 1, 1)
+        latent_coords = rearrange(
+            latent_coords, "b c f h w -> b c (f h w)", b=batch_size
+        )
+        return latent_coords
 
 
 class SymmetricPatchifier(Patchifier):
-    def patchify(
-        self,
-        latents: Tensor,
-    ) -> Tuple[Tensor, Tensor]:
+    def patchify(self, latents: Tensor) -> Tuple[Tensor, Tensor]:
+        b, _, f, h, w = latents.shape
+        latent_coords = self.get_latent_coords(f, h, w, b, latents.device)
         latents = rearrange(
             latents,
             "b c (f p1) (h p2) (w p3) -> b (f h w) (c p1 p2 p3)",
@@ -72,22 +62,20 @@ class SymmetricPatchifier(Patchifier):
             p2=self._patch_size[1],
             p3=self._patch_size[2],
         )
-        return latents
+        return latents, latent_coords
 
     def unpatchify(
         self,
         latents: Tensor,
         output_height: int,
         output_width: int,
-        output_num_frames: int,
         out_channels: int,
     ) -> Tuple[Tensor, Tensor]:
         output_height = output_height // self._patch_size[1]
         output_width = output_width // self._patch_size[2]
         latents = rearrange(
             latents,
-            "b (f h w) (c p q) -> b c f (h p) (w q) ",
-            f=output_num_frames,
+            "b (f h w) (c p q) -> b c f (h p) (w q)",
             h=output_height,
             w=output_width,
             p=self._patch_size[1],

--- a/ltx_video/models/transformers/transformer3d.py
+++ b/ltx_video/models/transformers/transformer3d.py
@@ -79,6 +79,7 @@ class Transformer3DModel(ModelMixin, ConfigMixin):
         positional_embedding_theta: Optional[float] = None,
         positional_embedding_max_pos: Optional[List[int]] = None,
         timestep_scale_multiplier: Optional[float] = None,
+        causal_temporal_positioning: bool = False,  # For backward compatibility, will be deprecated
     ):
         super().__init__()
         self.use_tpu_flash_attention = (

--- a/ltx_video/pipelines/pipeline_ltx_video.py
+++ b/ltx_video/pipelines/pipeline_ltx_video.py
@@ -297,7 +297,7 @@ class LTXVideoPipeline(DiffusionPipeline):
 
         # See Section 3.1. of the paper.
         # FIXME: to be configured in config not hardecoded. Fix in separate PR with rest of config
-        max_length = 128  # TPU supports only lengths multiple of 128
+        max_length = 256  # TPU supports only lengths multiple of 128
         if prompt_embeds is None:
             assert (
                 self.text_encoder is not None

--- a/ltx_video/utils/conditioning_method.py
+++ b/ltx_video/utils/conditioning_method.py
@@ -1,6 +1,0 @@
-from enum import Enum
-
-
-class ConditioningMethod(Enum):
-    UNCONDITIONAL = "unconditional"
-    FIRST_FRAME = "first_frame"

--- a/ltx_video/utils/prompt_enhance_utils.py
+++ b/ltx_video/utils/prompt_enhance_utils.py
@@ -1,0 +1,226 @@
+import logging
+from typing import Union, List, Optional
+
+import torch
+from PIL import Image
+
+logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
+T2V_CINEMATIC_PROMPT = """You are an expert cinematic director with many award winning movies, When writing prompts based on the user input, focus on detailed, chronological descriptions of actions and scenes.
+Include specific movements, appearances, camera angles, and environmental details - all in a single flowing paragraph.
+Start directly with the action, and keep descriptions literal and precise.
+Think like a cinematographer describing a shot list.
+Do not change the user input intent, just enhance it.
+Keep within 150 words.
+For best results, build your prompts using this structure:
+Start with main action in a single sentence
+Add specific details about movements and gestures
+Describe character/object appearances precisely
+Include background and environment details
+Specify camera angles and movements
+Describe lighting and colors
+Note any changes or sudden events
+Do not exceed the 150 word limit!
+Output the enhanced prompt only.
+"""
+
+I2V_CINEMATIC_PROMPT = """You are an expert cinematic director with many award winning movies, When writing prompts based on the user input, focus on detailed, chronological descriptions of actions and scenes.
+Include specific movements, appearances, camera angles, and environmental details - all in a single flowing paragraph.
+Start directly with the action, and keep descriptions literal and precise.
+Think like a cinematographer describing a shot list.
+Keep within 150 words.
+For best results, build your prompts using this structure:
+Describe the image first and then add the user input. Image description should be in first priority! Align to the image caption if it contradicts the user text input.
+Start with main action in a single sentence
+Add specific details about movements and gestures
+Describe character/object appearances precisely
+Include background and environment details
+Specify camera angles and movements
+Describe lighting and colors
+Note any changes or sudden events
+Align to the image caption if it contradicts the user text input.
+Do not exceed the 150 word limit!
+Output the enhanced prompt only.
+"""
+
+
+def tensor_to_pil(tensor):
+    # Ensure tensor is in range [-1, 1]
+    assert tensor.min() >= -1 and tensor.max() <= 1
+
+    # Convert from [-1, 1] to [0, 1]
+    tensor = (tensor + 1) / 2
+
+    # Rearrange from [C, H, W] to [H, W, C]
+    tensor = tensor.permute(1, 2, 0)
+
+    # Convert to numpy array and then to uint8 range [0, 255]
+    numpy_image = (tensor.cpu().numpy() * 255).astype("uint8")
+
+    # Convert to PIL Image
+    return Image.fromarray(numpy_image)
+
+
+def generate_cinematic_prompt(
+    image_caption_model,
+    image_caption_processor,
+    prompt_enhancer_model,
+    prompt_enhancer_tokenizer,
+    prompt: Union[str, List[str]],
+    conditioning_items: Optional[List] = None,
+    max_new_tokens: int = 256,
+) -> List[str]:
+    prompts = [prompt] if isinstance(prompt, str) else prompt
+
+    if conditioning_items is None:
+        prompts = _generate_t2v_prompt(
+            prompt_enhancer_model,
+            prompt_enhancer_tokenizer,
+            prompts,
+            max_new_tokens,
+            T2V_CINEMATIC_PROMPT,
+        )
+    else:
+        if len(conditioning_items) > 1 or conditioning_items[0].media_frame_number != 0:
+            logger.warning(
+                "prompt enhancement does only support unconditional or first frame of conditioning items, returning original prompts"
+            )
+            return prompts
+
+        first_frame_conditioning_item = conditioning_items[0]
+        first_frames = _get_first_frames_from_conditioning_item(
+            first_frame_conditioning_item
+        )
+
+        assert len(first_frames) == len(
+            prompts
+        ), "Number of conditioning frames must match number of prompts"
+
+        prompts = _generate_i2v_prompt(
+            image_caption_model,
+            image_caption_processor,
+            prompt_enhancer_model,
+            prompt_enhancer_tokenizer,
+            prompts,
+            first_frames,
+            max_new_tokens,
+            I2V_CINEMATIC_PROMPT,
+        )
+
+    return prompts
+
+
+def _get_first_frames_from_conditioning_item(conditioning_item) -> List[Image.Image]:
+    frames_tensor = conditioning_item.media_item
+    return [
+        tensor_to_pil(frames_tensor[i, :, 0, :, :])
+        for i in range(frames_tensor.shape[0])
+    ]
+
+
+def _generate_t2v_prompt(
+    prompt_enhancer_model,
+    prompt_enhancer_tokenizer,
+    prompts: List[str],
+    max_new_tokens: int,
+    system_prompt: str,
+) -> List[str]:
+    messages = [
+        [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": f"user_prompt: {p}"},
+        ]
+        for p in prompts
+    ]
+
+    texts = [
+        prompt_enhancer_tokenizer.apply_chat_template(
+            m, tokenize=False, add_generation_prompt=True
+        )
+        for m in messages
+    ]
+    model_inputs = prompt_enhancer_tokenizer(texts, return_tensors="pt").to(
+        prompt_enhancer_model.device
+    )
+
+    return _generate_and_decode_prompts(
+        prompt_enhancer_model, prompt_enhancer_tokenizer, model_inputs, max_new_tokens
+    )
+
+
+def _generate_i2v_prompt(
+    image_caption_model,
+    image_caption_processor,
+    prompt_enhancer_model,
+    prompt_enhancer_tokenizer,
+    prompts: List[str],
+    first_frames: List[Image.Image],
+    max_new_tokens: int,
+    system_prompt: str,
+) -> List[str]:
+    image_captions = _generate_image_captions(
+        image_caption_model, image_caption_processor, first_frames
+    )
+
+    messages = [
+        [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": f"user_prompt: {p}\nimage_caption: {c}"},
+        ]
+        for p, c in zip(prompts, image_captions)
+    ]
+
+    texts = [
+        prompt_enhancer_tokenizer.apply_chat_template(
+            m, tokenize=False, add_generation_prompt=True
+        )
+        for m in messages
+    ]
+    model_inputs = prompt_enhancer_tokenizer(texts, return_tensors="pt").to(
+        prompt_enhancer_model.device
+    )
+
+    return _generate_and_decode_prompts(
+        prompt_enhancer_model, prompt_enhancer_tokenizer, model_inputs, max_new_tokens
+    )
+
+
+def _generate_image_captions(
+    image_caption_model,
+    image_caption_processor,
+    images: List[Image.Image],
+    system_prompt: str = "<DETAILED_CAPTION>",
+) -> List[str]:
+    image_caption_prompts = [system_prompt] * len(images)
+    inputs = image_caption_processor(
+        image_caption_prompts, images, return_tensors="pt"
+    ).to(image_caption_model.device)
+
+    with torch.inference_mode():
+        generated_ids = image_caption_model.generate(
+            input_ids=inputs["input_ids"],
+            pixel_values=inputs["pixel_values"],
+            max_new_tokens=1024,
+            do_sample=False,
+            num_beams=3,
+        )
+
+    return image_caption_processor.batch_decode(generated_ids, skip_special_tokens=True)
+
+
+def _generate_and_decode_prompts(
+    prompt_enhancer_model, prompt_enhancer_tokenizer, model_inputs, max_new_tokens: int
+) -> List[str]:
+    with torch.inference_mode():
+        outputs = prompt_enhancer_model.generate(
+            **model_inputs, max_new_tokens=max_new_tokens
+        )
+        generated_ids = [
+            output_ids[len(input_ids) :]
+            for input_ids, output_ids in zip(model_inputs.input_ids, outputs)
+        ]
+        decoded_prompts = prompt_enhancer_tokenizer.batch_decode(
+            generated_ids, skip_special_tokens=True
+        )
+
+    return decoded_prompts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,11 @@ classifiers = [
 dependencies = [
     "torch>=2.1.0",
     "diffusers>=0.28.2",
-    "transformers>=4.44.2",
+    "transformers>=4.47.2",
     "sentencepiece>=0.1.96",
     "huggingface-hub~=0.25.2",
-    "einops"
+    "einops",
+    "timm"
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,12 @@ def test_paths(request, pytestconfig):
             "text_encoder_model_name_or_path"
         )
         input_image_path = pytestconfig.getoption("input_image_path")
+        input_video_path = pytestconfig.getoption("input_video_path")
 
         config = {
             "ckpt_path": ckpt_path,
             "input_image_path": input_image_path,
+            "input_video_path": input_video_path,
             "output_path": output_path,
             "text_encoder_model_name_or_path": text_encoder_model_name_or_path,
         }
@@ -49,6 +51,12 @@ def pytest_addoption(parser):
     parser.addoption(
         "--input_image_path",
         action="store",
-        default="tests/utils/car.png",
+        default="tests/utils/woman.jpeg",
         help="Path to input image file.",
+    )
+    parser.addoption(
+        "--input_video_path",
+        action="store",
+        default="tests/utils/woman.mp4",
+        help="Path to input video file.",
     )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,96 @@
+import pytest
+import torch
+from ltx_video.schedulers.rf import RectifiedFlowScheduler
+
+
+def init_latents_and_scheduler(sampler):
+    batch_size, n_tokens, n_channels = 2, 4096, 128
+    num_steps = 20
+    scheduler = RectifiedFlowScheduler(
+        sampler=("Uniform" if sampler.lower() == "uniform" else "LinearQuadratic")
+    )
+    latents = torch.randn(size=(batch_size, n_tokens, n_channels))
+    scheduler.set_timesteps(num_inference_steps=num_steps, samples=latents)
+    return scheduler, latents
+
+
+@pytest.mark.parametrize("sampler", ["LinearQuadratic", "Uniform"])
+def test_scheduler_default_behavior(sampler):
+    """
+    Test the case of a single timestep from the list of timesteps.
+    """
+    scheduler, latents = init_latents_and_scheduler(sampler)
+
+    for i, t in enumerate(scheduler.timesteps):
+        noise_pred = torch.randn_like(latents)
+        denoised_latents = scheduler.step(
+            noise_pred,
+            t,
+            latents,
+            return_dict=False,
+        )[0]
+
+        # Verify the denoising
+        next_t = scheduler.timesteps[i + 1] if i < len(scheduler.timesteps) - 1 else 0.0
+        dt = t - next_t
+        expected_denoised_latents = latents - dt * noise_pred
+        assert torch.allclose(denoised_latents, expected_denoised_latents, atol=1e-06)
+
+
+@pytest.mark.parametrize("sampler", ["LinearQuadratic", "Uniform"])
+def test_scheduler_per_token(sampler):
+    """
+    Test the case of a timestep per token (from the list of timesteps).
+    Some tokens are set with timestep of 0.
+    """
+    scheduler, latents = init_latents_and_scheduler(sampler)
+    batch_size, n_tokens = latents.shape[:2]
+    for i, t in enumerate(scheduler.timesteps):
+        timesteps = torch.full((batch_size, n_tokens), t)
+        timesteps[:, 0] = 0.0
+        noise_pred = torch.randn_like(latents)
+        denoised_latents = scheduler.step(
+            noise_pred,
+            timesteps,
+            latents,
+            return_dict=False,
+        )[0]
+
+        # Verify the denoising
+        next_t = scheduler.timesteps[i + 1] if i < len(scheduler.timesteps) - 1 else 0.0
+        next_timesteps = torch.full((batch_size, n_tokens), next_t)
+        dt = timesteps - next_timesteps
+        expected_denoised_latents = latents - dt.unsqueeze(-1) * noise_pred
+        assert torch.allclose(
+            denoised_latents[:, 1:], expected_denoised_latents[:, 1:], atol=1e-06
+        )
+        assert torch.allclose(denoised_latents[:, 0], latents[:, 0], atol=1e-06)
+
+
+@pytest.mark.parametrize("sampler", ["LinearQuadratic", "Uniform"])
+def test_scheduler_t_not_in_list(sampler):
+    """
+    Test the case of a timestep per token NOT from the list of timesteps.
+    """
+    scheduler, latents = init_latents_and_scheduler(sampler)
+    batch_size, n_tokens = latents.shape[:2]
+    for i in range(len(scheduler.timesteps)):
+        if i < len(scheduler.timesteps) - 1:
+            t = (scheduler.timesteps[i] + scheduler.timesteps[i + 1]) / 2
+        else:
+            t = scheduler.timesteps[i] / 2
+        timesteps = torch.full((batch_size, n_tokens), t)
+        noise_pred = torch.randn_like(latents)
+        denoised_latents = scheduler.step(
+            noise_pred,
+            timesteps,
+            latents,
+            return_dict=False,
+        )[0]
+
+        # Verify the denoising
+        next_t = scheduler.timesteps[i + 1] if i < len(scheduler.timesteps) - 1 else 0.0
+        next_timesteps = torch.full((batch_size, n_tokens), next_t)
+        dt = timesteps - next_timesteps
+        expected_denoised_latents = latents - dt.unsqueeze(-1) * noise_pred
+        assert torch.allclose(denoised_latents, expected_denoised_latents, atol=1e-06)

--- a/tests/utils/.gitattributes
+++ b/tests/utils/.gitattributes
@@ -1,0 +1,1 @@
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/tests/utils/car.png
+++ b/tests/utils/car.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef275020c1d26e926dfbb19c2ed5d7006650040e5cfc941250d920f90fcf33af
-size 798449

--- a/tests/utils/woman.jpeg
+++ b/tests/utils/woman.jpeg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:acf0a6de9f7fb5551702fa8065ab423811e2011c36338f49636f84b033715df8
+size 33249

--- a/tests/utils/woman.mp4
+++ b/tests/utils/woman.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:833c2a0afe03ad60cb0c6361433eb11acf2ed58890f6b411cd306c01069e199f
+size 73228


### PR DESCRIPTION
This pull request includes several updates and new features for the `README.md`, `inference.py` and the pipeline files, and changes in the architecture required for LTX-Video-v0.9.5.

Functionality changes include:

- New license for commercial use ([OpenRail-M](https://huggingface.co/Lightricks/LTX-Video/ltx-video-2b-v0.9.5.license.txt)) - the license of the old checkpoints remains unchanged
- Release a new checkpoint v0.9.5 with improved quality
- Support keyframes and video extension
- Support higher resolutions
- Improved prompt understanding
- Improved VAE
- New online web app in [LTX-Studio](https://app.ltx.studio/ltx-video)
- Automatic prompt enhancement

The code is compatible with older checkpoints.