### PR TITLE
Reduce inference VRAM usage

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -343,9 +343,15 @@ def create_ltx_video_pipeline(
         text_encoder_model_name_or_path, subfolder="tokenizer"
     )
 
-    transformer = transformer.to(device)
-    vae = vae.to(device)
-    text_encoder = text_encoder.to(device)
+    # Move models to the specified device
+    if precision == "bfloat16":
+        transformer = transformer.to(device, torch.bfloat16)
+    else: 
+        transformer = transformer.to(device)
+
+    vae = vae.to(device, dtype=torch.bfloat16)
+
+    text_encoder = text_encoder.to(device, dtype=torch.bfloat16)
 
     if enhance_prompt:
         prompt_enhancer_image_caption_model = AutoModelForCausalLM.from_pretrained(
@@ -366,11 +372,6 @@ def create_ltx_video_pipeline(
         prompt_enhancer_image_caption_processor = None
         prompt_enhancer_llm_model = None
         prompt_enhancer_llm_tokenizer = None
-
-    vae = vae.to(torch.bfloat16)
-    if precision == "bfloat16" and transformer.dtype != torch.bfloat16:
-        transformer = transformer.to(torch.bfloat16)
-    text_encoder = text_encoder.to(torch.bfloat16)
 
     # Use submodels for the pipeline
     submodel_dict = {

--- a/inference.py
+++ b/inference.py
@@ -49,6 +49,11 @@ def get_total_gpu_memory():
     if torch.cuda.is_available():
         total_memory = torch.cuda.get_device_properties(0).total_memory / (1024**3)
         return total_memory
+    elif torch.backends.mps.is_available():
+        # MPS does not provide a direct way to get total memory, so we use system memory as a proxy
+        import psutil
+        total_memory = psutil.virtual_memory().total / (1024**3)
+        return total_memory
     return 0
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ inference-script = [
     "matplotlib",
     "imageio[ffmpeg]",
     "av",
-    "opencv-python"
+    "opencv-python",
+    "psutil; platform_system == 'Darwin'"
 ]
 test = [
     "pytest",


### PR DESCRIPTION
This PR contains 2 commits

1. Estimate the GPU memory on MacOS so that we don't always offload to CPU
2. Send models to the device directly with the appropriate `dtype` (avoiding a memory usage spike)

This allowed me to run inference on my laptop without running out of memory.