### PR TITLE
Add AMD ROCm 6.4 install constraints and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The model is accessible right away via the following links:
 ### Installation
 The codebase was tested with Python 3.10.5, CUDA version 12.2, and supports PyTorch >= 2.1.2.
 On macOS, MPS was tested with PyTorch 2.3.0, and should support PyTorch == 2.3 or >= 2.6.
+(**For AMD Instinct/ROCm, see the section below.**)
 
 ```bash
 git clone https://github.com/Lightricks/LTX-Video.git
@@ -186,6 +187,22 @@ cd LTX-Video
 python -m venv env
 source env/bin/activate
 python -m pip install -e .\[inference\]
+```
+
+#### Installation for AMD Instinct GPUs 
+Tested on Python 3.11 with PyTorch 2.8.0 (ROCm 6.4) on Linux x86_64. To install on AMD Instinct GPUs, run:
+
+```bash
+git clone https://github.com/Lightricks/LTX-Video.git
+cd LTX-Video
+
+# create env
+python -m venv env
+source env/bin/activate
+pip install -e .[inference] \
+  -c constraints/rocm6.4.txt \
+  --index-url https://download.pytorch.org/whl/rocm6.4 \
+  --extra-index-url https://pypi.org/simple
 ```
 
 #### FP8 Kernels (optional)

--- a/constraints/rocm6.4.txt
+++ b/constraints/rocm6.4.txt
@@ -1,0 +1,2 @@
+torch==2.8.0+rocm6.4
+torchvision==0.23.0+rocm6.4


### PR DESCRIPTION
Verified compatibility with **AMD Instinct GPUs (ROCm 6.4, PyTorch 2.8.0, Python 3.11)**.

This PR keeps the existing `pyproject.toml` unchanged and adds:
- ROCm constraint file (`constraints/rocm6.4.txt`)
- Updated README with AMD installation instructions

## Notes
- Let me know if you’d like access to an AMD GPU for verification or further testing.
- Happy to support with any follow-ups.